### PR TITLE
chore(release): bump rockspec to v2.1-0

### DIFF
--- a/mattata-2.1-0.rockspec
+++ b/mattata-2.1-0.rockspec
@@ -1,7 +1,8 @@
 package = 'mattata'
-version = '2.0-0'
+version = '2.1-0'
 source = {
-    url = 'git://github.com/wrxck/mattata.git'
+    url = 'git://github.com/wrxck/mattata.git',
+    tag = 'v2.1.0'
 }
 description = {
     summary = 'A feature-rich Telegram bot written in Lua',


### PR DESCRIPTION
## Summary
- Renames rockspec from 2.0-0 to 2.1-0 to match current version
- Adds `tag = 'v2.1.0'` to rockspec source for LuaRocks compatibility