### PR TITLE
fix(content): configurable links, command menu, enhanced /id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ SPOTIFY_CLIENT_ID=
 SPOTIFY_CLIENT_SECRET=
 SPAMWATCH_TOKEN=
 
+# Bot links (optional, defaults shown)
+CHANNEL_URL=https://t.me/mattata
+SUPPORT_URL=https://t.me/mattataSupport
+GITHUB_URL=https://github.com/wrxck/mattata
+DEV_URL=https://t.me/mattataDev
+
 # Logging
 LOG_CHAT=
 DEBUG=false

--- a/src/plugins/utility/about.lua
+++ b/src/plugins/utility/about.lua
@@ -12,9 +12,11 @@ plugin.permanent = true
 
 function plugin.on_message(api, message, ctx)
     local config = require('src.core.config')
+    local owner_id = config.get_list('BOT_ADMINS')[1] or '221714512'
+    local github_url = config.get('GITHUB_URL', 'https://github.com/wrxck/mattata')
     local output = string.format(
-        'Created by <a href="tg://user?id=221714512">Matt</a>. Powered by <code>mattata v%s</code>. Source code available <a href="https://github.com/wrxck/mattata">on GitHub</a>.',
-        config.VERSION
+        'Created by <a href="tg://user?id=%s">Matt</a>. Powered by <code>mattata v%s</code>. Source code available <a href="%s">on GitHub</a>.',
+        owner_id, config.VERSION, github_url
     )
     return api.send_message(message.chat.id, output, 'html')
 end

--- a/src/plugins/utility/help.lua
+++ b/src/plugins/utility/help.lua
@@ -114,12 +114,17 @@ function plugin.on_callback_query(api, callback_query, message, ctx)
         return api.edit_message_text(message.chat.id, message.message_id, output, 'html', true, keyboard)
 
     elseif data == 'links' then
+        local cfg = require('src.core.config')
+        local channel_url = cfg.get('CHANNEL_URL', 'https://t.me/mattata')
+        local support_url = cfg.get('SUPPORT_URL', 'https://t.me/mattataSupport')
+        local github_url = cfg.get('GITHUB_URL', 'https://github.com/wrxck/mattata')
+        local dev_url = cfg.get('DEV_URL', 'https://t.me/mattataDev')
         local keyboard = api.inline_keyboard():row(
-            api.row():url_button('Development', 'https://t.me/mattataDev')
-                :url_button('Channel', 'https://t.me/mattata')
+            api.row():url_button('Development', dev_url)
+                :url_button('Channel', channel_url)
         ):row(
-            api.row():url_button('GitHub', 'https://github.com/wrxck/mattata')
-                :url_button('Support', 'https://t.me/mattataSupport')
+            api.row():url_button('GitHub', github_url)
+                :url_button('Support', support_url)
         ):row(
             api.row():callback_data_button('Back', 'help:back')
         )

--- a/src/plugins/utility/id.lua
+++ b/src/plugins/utility/id.lua
@@ -1,6 +1,6 @@
 --[[
-    mattata v2.0 - ID Plugin
-    Returns user/chat ID and information.
+    mattata v2.1 - ID Plugin
+    Returns user/chat ID and information with modern Telegram fields.
 ]]
 
 local plugin = {}
@@ -43,6 +43,21 @@ function plugin.on_message(api, message, ctx)
     if target.language_code then
         table.insert(lines, 'Language: <code>' .. target.language_code .. '</code>')
     end
+    if target.is_bot then
+        table.insert(lines, 'Bot: Yes')
+    end
+    if target.is_premium then
+        table.insert(lines, 'Premium: Yes')
+    end
+    if target.added_to_attachment_menu then
+        table.insert(lines, 'Attachment menu: Yes')
+    end
+
+    -- Profile photo count
+    local photos = api.get_user_profile_photos(target.id, 0, 1)
+    if photos and photos.result and photos.result.total_count then
+        table.insert(lines, 'Profile photos: ' .. photos.result.total_count)
+    end
 
     -- If in a group, also show chat info
     if ctx.is_group then
@@ -53,6 +68,23 @@ function plugin.on_message(api, message, ctx)
         table.insert(lines, 'Type: ' .. (message.chat.type or 'unknown'))
         if message.chat.username then
             table.insert(lines, 'Username: @' .. message.chat.username)
+        end
+        if message.chat.is_forum then
+            table.insert(lines, 'Forum: Yes')
+        end
+        -- Fetch full chat info for extra details
+        local chat_info = api.get_chat(message.chat.id)
+        if chat_info and chat_info.result then
+            local chat = chat_info.result
+            if chat.linked_chat_id then
+                table.insert(lines, 'Linked chat: <code>' .. chat.linked_chat_id .. '</code>')
+            end
+            if chat.has_hidden_members then
+                table.insert(lines, 'Hidden members: Yes')
+            end
+            if chat.has_aggressive_anti_spam_enabled then
+                table.insert(lines, 'Aggressive anti-spam: Yes')
+            end
         end
     end
 


### PR DESCRIPTION
## Summary
- Make hardcoded links configurable in about.lua (`BOT_ADMINS[1]` for owner) and help.lua (`CHANNEL_URL`, `SUPPORT_URL`, `GITHUB_URL`, `DEV_URL`)
- Register bot command menu on startup via `set_my_commands` with separate admin-scoped command list
- Enhance `/id` with premium status, profile photo count, bot flag, forum status, linked chat, and anti-spam fields

## Test plan
- [ ] Test `/about` shows correct owner link from `BOT_ADMINS`
- [ ] Test `/help` > Links shows correct URLs (default or custom)
- [ ] Verify command autocomplete appears in Telegram after restart
- [ ] Test `/id` shows premium status, photo count, forum info in groups
- [ ] Test `/id @username` and reply-to-message modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)