### PR TITLE
feat(plugins): add poll, react, boosts, and bulk ops

### DIFF
--- a/src/plugins/admin/bulkops.lua
+++ b/src/plugins/admin/bulkops.lua
@@ -1,0 +1,46 @@
+--[[
+    mattata v2.1 - Bulk Operations Plugin
+    Forward or copy messages between chats.
+]]
+
+local plugin = {}
+plugin.name = 'bulkops'
+plugin.category = 'admin'
+plugin.description = 'Forward or copy messages'
+plugin.commands = { 'forward', 'copy' }
+plugin.help = '/forward <chat_id> - Forward the replied message to another chat.\n/copy <chat_id> - Copy the replied message to another chat (without forward header).'
+plugin.admin_only = true
+
+function plugin.on_message(api, message, ctx)
+    if not message.reply then
+        return api.send_message(message.chat.id, 'Reply to a message with /' .. message.command .. ' <chat_id> to ' .. message.command .. ' it.')
+    end
+
+    if not message.args or message.args == '' then
+        return api.send_message(message.chat.id, 'Usage: /' .. message.command .. ' <chat_id>')
+    end
+
+    local target_chat = tonumber(message.args)
+    if not target_chat then
+        -- Try to resolve as username
+        target_chat = message.args:match('^@?(.+)$')
+    end
+
+    if not target_chat then
+        return api.send_message(message.chat.id, 'Invalid chat ID or username.')
+    end
+
+    local result
+    if message.command == 'forward' then
+        result = api.forward_messages(target_chat, message.chat.id, { message.reply.message_id })
+    else
+        result = api.copy_messages(target_chat, message.chat.id, { message.reply.message_id })
+    end
+
+    if result then
+        return api.send_message(message.chat.id, 'Message ' .. message.command .. 'ed successfully.')
+    end
+    return api.send_message(message.chat.id, 'Failed to ' .. message.command .. ' the message. Make sure the bot has access to the target chat.')
+end
+
+return plugin

--- a/src/plugins/admin/init.lua
+++ b/src/plugins/admin/init.lua
@@ -45,6 +45,7 @@ return {
         'pin',
         'allowedlinks',
         'allowlink',
+        'bulkops',
         -- Federation sub-package
         'federation.newfed',
         'federation.delfed',

--- a/src/plugins/fun/init.lua
+++ b/src/plugins/fun/init.lua
@@ -16,6 +16,7 @@ return {
         'catfact',
         'inspirobot',
         'quote',
-        'game'
+        'game',
+        'react'
     }
 }

--- a/src/plugins/fun/react.lua
+++ b/src/plugins/fun/react.lua
@@ -1,0 +1,38 @@
+--[[
+    mattata v2.1 - React Plugin
+    Set message reactions via the Bot API.
+]]
+
+local plugin = {}
+plugin.name = 'react'
+plugin.category = 'fun'
+plugin.description = 'React to messages with emoji'
+plugin.commands = { 'react' }
+plugin.help = '/react <emoji> - Reply to a message to react with the specified emoji.'
+
+local json = require('dkjson')
+
+function plugin.on_message(api, message, ctx)
+    if not message.reply then
+        return api.send_message(message.chat.id, 'Reply to a message with /react <emoji> to add a reaction.')
+    end
+
+    if not message.args or message.args == '' then
+        return api.send_message(message.chat.id, 'Usage: /react <emoji>\n\nExample: /react \xF0\x9F\x91\x8D')
+    end
+
+    local emoji = message.args:match('^%s*(.-)%s*$')
+    local reaction = json.encode({
+        { type = 'emoji', emoji = emoji }
+    })
+
+    local result = api.set_message_reaction(message.chat.id, message.reply.message_id, { reaction = reaction })
+    if result then
+        -- Delete the command message to keep chat clean
+        api.delete_message(message.chat.id, message.message_id)
+    else
+        return api.send_message(message.chat.id, 'Failed to set reaction. The emoji may not be supported.')
+    end
+end
+
+return plugin

--- a/src/plugins/utility/boosts.lua
+++ b/src/plugins/utility/boosts.lua
@@ -1,0 +1,69 @@
+--[[
+    mattata v2.1 - Boosts Plugin
+    View chat boost stats for users.
+    Hooks into on_chat_boost to notify when the chat is boosted.
+]]
+
+local plugin = {}
+plugin.name = 'boosts'
+plugin.category = 'utility'
+plugin.description = 'View chat boost info'
+plugin.commands = { 'boosts', 'boost' }
+plugin.help = '/boosts [user] - View boost count for yourself or a user in this chat.'
+plugin.group_only = true
+
+function plugin.on_message(api, message, ctx)
+    local tools = require('telegram-bot-lua.tools')
+
+    local target_id = message.from.id
+    local target_name = message.from.first_name
+
+    if message.reply and message.reply.from then
+        target_id = message.reply.from.id
+        target_name = message.reply.from.first_name
+    elseif message.args and message.args ~= '' then
+        local resolved = message.args:match('^@?(.+)$')
+        local uid = tonumber(resolved) or ctx.redis.get('username:' .. resolved:lower())
+        if uid then
+            target_id = tonumber(uid)
+            local user_info = api.get_chat(target_id)
+            if user_info and user_info.result then
+                target_name = user_info.result.first_name or 'User'
+            end
+        end
+    end
+
+    local result = api.get_user_chat_boosts(message.chat.id, target_id)
+    if result and result.result and result.result.boosts then
+        local boosts = result.result.boosts
+        if #boosts == 0 then
+            return api.send_message(message.chat.id, string.format(
+                '<b>%s</b> has not boosted this chat.',
+                tools.escape_html(target_name)
+            ), 'html')
+        end
+        local lines = { string.format('<b>%s</b> has <b>%d</b> boost(s) in this chat:', tools.escape_html(target_name), #boosts) }
+        for i, boost in ipairs(boosts) do
+            local expire = boost.expiration_date and os.date('%Y-%m-%d', boost.expiration_date) or 'never'
+            table.insert(lines, string.format('%d. Added %s, expires %s', i, os.date('%Y-%m-%d', boost.add_date), expire))
+        end
+        return api.send_message(message.chat.id, table.concat(lines, '\n'), 'html')
+    end
+
+    return api.send_message(message.chat.id, 'Failed to retrieve boost information.')
+end
+
+-- Notify chat when it receives a new boost
+function plugin.on_chat_boost(api, boost, ctx)
+    if not boost.boost or not boost.boost.source then return end
+    local source = boost.boost.source
+    if source.user then
+        local tools = require('telegram-bot-lua.tools')
+        api.send_message(boost.chat.id, string.format(
+            '\xF0\x9F\x9A\x80 <a href="tg://user?id=%d">%s</a> just boosted this chat!',
+            source.user.id, tools.escape_html(source.user.first_name)
+        ), 'html')
+    end
+end
+
+return plugin

--- a/src/plugins/utility/init.lua
+++ b/src/plugins/utility/init.lua
@@ -32,6 +32,8 @@ return {
         'xkcd',
         'pokedex',
         'lastfm',
-        'plugins'
+        'plugins',
+        'poll',
+        'boosts'
     }
 }

--- a/src/plugins/utility/poll.lua
+++ b/src/plugins/utility/poll.lua
@@ -1,0 +1,60 @@
+--[[
+    mattata v2.1 - Poll Plugin
+    Create polls and quizzes via Telegram's native poll API.
+]]
+
+local plugin = {}
+plugin.name = 'poll'
+plugin.category = 'utility'
+plugin.description = 'Create polls and quizzes'
+plugin.commands = { 'poll', 'quiz' }
+plugin.help = '/poll Question? | Option 1 | Option 2 | ... - Create a poll.\n/quiz Question? | Correct Answer | Wrong 1 | Wrong 2 - Create a quiz (first option is correct).'
+
+local json = require('dkjson')
+
+function plugin.on_message(api, message, ctx)
+    if not message.args or message.args == '' then
+        if message.command == 'quiz' then
+            return api.send_message(message.chat.id, 'Usage: /quiz Question? | Correct Answer | Wrong 1 | Wrong 2\n\nThe first option is the correct answer.')
+        end
+        return api.send_message(message.chat.id, 'Usage: /poll Question? | Option 1 | Option 2 | ...\n\nSeparate options with |. Minimum 2 options, maximum 10.')
+    end
+
+    -- Parse question and options
+    local parts = {}
+    for part in message.args:gmatch('[^|]+') do
+        part = part:match('^%s*(.-)%s*$')
+        if part ~= '' then
+            table.insert(parts, part)
+        end
+    end
+
+    if #parts < 3 then
+        return api.send_message(message.chat.id, 'You need at least a question and 2 options. Separate them with |.')
+    end
+
+    if #parts > 11 then
+        return api.send_message(message.chat.id, 'Maximum 10 options allowed.')
+    end
+
+    local question = parts[1]
+    local options = {}
+    for i = 2, #parts do
+        table.insert(options, parts[i])
+    end
+
+    local is_quiz = message.command == 'quiz'
+
+    local opts = {
+        is_anonymous = false
+    }
+
+    if is_quiz then
+        opts.type = 'quiz'
+        opts.correct_option_id = 0 -- First option is correct
+    end
+
+    return api.send_poll(message.chat.id, question, json.encode(options), opts)
+end
+
+return plugin


### PR DESCRIPTION
## Summary
- **poll**: Create polls and quizzes via `/poll Question | Opt1 | Opt2` and `/quiz Question | Correct | Wrong1 | Wrong2`; uses native Telegram poll API
- **react**: Reply to messages with `/react <emoji>` to set reactions; auto-deletes command message
- **boosts**: `/boosts [user]` shows boost count; hooks `on_chat_boost` for notifications
- **bulkops**: `/forward <chat_id>` and `/copy <chat_id>` to forward/copy replied messages

Depends on #94 (router expansion) for poll, reaction, and boost hooks.

## Test plan
- [ ] Test `/poll Question? | Yes | No | Maybe`
- [ ] Test `/quiz Capital of France? | Paris | London | Berlin`
- [ ] Test `/react 👍` in reply to a message
- [ ] Test `/boosts` and `/boosts @username` in a group
- [ ] Test `/forward <chat_id>` in reply to a message
- [ ] Test `/copy <chat_id>` in reply to a message

🤖 Generated with [Claude Code](https://claude.com/claude-code)