### PR TITLE
fix(lint): resolve all luacheck warnings across codebase

### DIFF
--- a/src/core/database.lua
+++ b/src/core/database.lua
@@ -178,7 +178,7 @@ function database.execute(sql, params)
             -- Release the dead connection's permit before reconnect
             if pool_semaphore then pool_semaphore:give(1) end
             local new_pg
-            new_pg, _ = create_connection()
+            new_pg = create_connection()
             if new_pg then
                 -- Re-acquire a permit for the new connection
                 if pool_semaphore then
@@ -342,7 +342,7 @@ function database.call(func_name, params, nparams)
             pcall(function() pg:disconnect() end)
             if pool_semaphore then pool_semaphore:give(1) end
             local new_pg
-            new_pg, _ = create_connection()
+            new_pg = create_connection()
             if new_pg then
                 if pool_semaphore then
                     local ok, sem_err = pool_semaphore:take(1, 30)

--- a/src/core/loader.lua
+++ b/src/core/loader.lua
@@ -14,7 +14,6 @@ local by_name = {}           -- name -> plugin lookup
 local categories = {}        -- category -> list of plugin names
 local by_event = {}          -- event_name -> list of plugins with that handler
 
-local PERMANENT_PLUGINS = { 'help', 'about', 'plugins' }
 local PERMANENT_SET = { help = true, about = true, plugins = true }
 
 -- Event handler names to index for fast dispatch

--- a/src/core/router.lua
+++ b/src/core/router.lua
@@ -359,61 +359,6 @@ local function on_inline_query(inline_query)
     dispatch_event('on_inline_query', inline_query, ctx)
 end
 
--- Handle chat join request
-local function on_chat_join_request(request)
-    if not request or not request.from then return end
-    if session.is_globally_blocklisted(request.from.id) then return end
-    dispatch_event('on_chat_join_request', request, build_ctx({ from = request.from, chat = request.chat }))
-end
-
--- Handle chat member status change (not the bot itself)
-local function on_chat_member(update)
-    if not update or not update.from then return end
-    dispatch_event('on_chat_member_update', update, build_ctx({ from = update.from, chat = update.chat }))
-end
-
--- Handle bot's own chat member status change
-local function on_my_chat_member(update)
-    if not update or not update.from then return end
-    dispatch_event('on_my_chat_member', update, build_ctx({ from = update.from, chat = update.chat }))
-end
-
--- Handle message reaction updates
-local function on_message_reaction(update)
-    if not update then return end
-    dispatch_event('on_reaction', update, build_ctx({ from = update.user or update.actor_chat, chat = update.chat }))
-end
-
--- Handle anonymous reaction count updates (no user info)
-local function on_message_reaction_count(update)
-    if not update then return end
-    dispatch_event('on_reaction_count', update, build_ctx({ from = nil, chat = update.chat }))
-end
-
--- Handle chat boost updates
-local function on_chat_boost(update)
-    if not update or not update.chat then return end
-    dispatch_event('on_chat_boost', update, build_ctx({ from = nil, chat = update.chat }))
-end
-
--- Handle removed chat boost updates
-local function on_removed_chat_boost(update)
-    if not update or not update.chat then return end
-    dispatch_event('on_removed_chat_boost', update, build_ctx({ from = nil, chat = update.chat }))
-end
-
--- Handle poll state updates
-local function on_poll(poll)
-    if not poll then return end
-    dispatch_event('on_poll', poll, build_ctx({ from = nil, chat = { type = 'private' } }))
-end
-
--- Handle poll answer updates
-local function on_poll_answer(poll_answer)
-    if not poll_answer then return end
-    dispatch_event('on_poll_answer', poll_answer, build_ctx({ from = poll_answer.user, chat = { type = 'private' } }))
-end
-
 -- Handle chat join request updates
 local function on_chat_join_request(request)
     if not request or not request.from or not request.chat then return end
@@ -573,7 +518,6 @@ function router.run()
         on_chat_member = on_chat_member,
         on_my_chat_member = on_my_chat_member,
         on_message_reaction = on_message_reaction,
-        on_message_reaction_count = on_message_reaction_count,
         on_chat_boost = on_chat_boost,
         on_removed_chat_boost = on_removed_chat_boost,
         on_poll = on_poll,

--- a/src/plugins/admin/customcaptcha.lua
+++ b/src/plugins/admin/customcaptcha.lua
@@ -77,7 +77,9 @@ function plugin.on_message(api, message, ctx)
         end
         local question, answer = rest:match('^(.-)%s*|%s*(.+)$')
         if not question or question == '' or not answer or answer == '' then
-            return api.send_message(chat_id, 'Please separate the question and answer with a pipe character (|).\nExample: <code>/customcaptcha set What colour is the sky? | blue</code>', { parse_mode = 'html' })
+            local err_text = 'Please separate the question and answer with a pipe character (|).\n'
+                .. 'Example: <code>/customcaptcha set What colour is the sky? | blue</code>'
+            return api.send_message(chat_id, err_text, { parse_mode = 'html' })
         end
         question = question:match('^%s*(.-)%s*$')
         answer = answer:match('^%s*(.-)%s*$')

--- a/src/plugins/fun/catfact.lua
+++ b/src/plugins/fun/catfact.lua
@@ -13,7 +13,7 @@ plugin.help = '/catfact - Get a random cat fact from catfact.ninja.'
 function plugin.on_message(api, message, ctx)
     local http = require('src.core.http')
 
-    local data, code = http.get_json('https://catfact.ninja/fact')
+    local data, _ = http.get_json('https://catfact.ninja/fact')
 
     if not data then
         return api.send_message(message.chat.id, 'Failed to fetch a cat fact. Try again later.')

--- a/src/plugins/fun/reactions.lua
+++ b/src/plugins/fun/reactions.lua
@@ -37,14 +37,14 @@ function plugin.on_message(api, message, ctx)
 
     local arg = message.args:lower()
     if arg == 'on' or arg == 'enable' then
-        local ok, err = pcall(ctx.db.call, 'sp_upsert_chat_setting', { message.chat.id, 'reactions_enabled', 'true' })
+        local ok, _ = pcall(ctx.db.call, 'sp_upsert_chat_setting', { message.chat.id, 'reactions_enabled', 'true' })
         if not ok then
             return api.send_message(message.chat.id, 'Failed to update setting. Please try again.')
         end
         session.invalidate_setting(message.chat.id, 'reactions_enabled')
         return api.send_message(message.chat.id, 'Reaction karma has been enabled for this group.')
     elseif arg == 'off' or arg == 'disable' then
-        local ok, err = pcall(ctx.db.call, 'sp_upsert_chat_setting', { message.chat.id, 'reactions_enabled', 'false' })
+        local ok, _ = pcall(ctx.db.call, 'sp_upsert_chat_setting', { message.chat.id, 'reactions_enabled', 'false' })
         if not ok then
             return api.send_message(message.chat.id, 'Failed to update setting. Please try again.')
         end

--- a/src/plugins/media/cats.lua
+++ b/src/plugins/media/cats.lua
@@ -13,7 +13,7 @@ plugin.help = '/cat - Sends a random cat image.'
 function plugin.on_message(api, message, ctx)
     local http = require('src.core.http')
 
-    local data, code = http.get_json('https://api.thecatapi.com/v1/images/search')
+    local data, _ = http.get_json('https://api.thecatapi.com/v1/images/search')
 
     if not data then
         return api.send_message(message.chat.id, 'Failed to fetch a cat image. Please try again later.')

--- a/src/plugins/media/gif.lua
+++ b/src/plugins/media/gif.lua
@@ -29,7 +29,7 @@ function plugin.on_message(api, message, ctx)
         query, tenor_key
     )
 
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
 
     if not data then
         return api.send_message(message.chat.id, 'Failed to search Tenor. Please try again later.')

--- a/src/plugins/media/itunes.lua
+++ b/src/plugins/media/itunes.lua
@@ -25,7 +25,7 @@ function plugin.on_message(api, message, ctx)
         query
     )
 
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
 
     if not data then
         return api.send_message(message.chat.id, 'Failed to search iTunes. Please try again later.')

--- a/src/plugins/media/youtube.lua
+++ b/src/plugins/media/youtube.lua
@@ -31,7 +31,7 @@ function plugin.on_message(api, message, ctx)
         query, api_key
     )
 
-    local data, code = http.get_json(search_url)
+    local data, _ = http.get_json(search_url)
 
     if not data then
         return api.send_message(message.chat.id, 'Failed to search YouTube. Please try again later.')
@@ -55,7 +55,7 @@ function plugin.on_message(api, message, ctx)
         video_id, api_key
     )
 
-    local stats_data, stats_code = http.get_json(stats_url)
+    local stats_data, _ = http.get_json(stats_url)
 
     local views = 'N/A'
     if stats_data then

--- a/src/plugins/utility/currency.lua
+++ b/src/plugins/utility/currency.lua
@@ -20,7 +20,7 @@ local function convert(amount, from, to)
         'https://api.frankfurter.app/latest?amount=%.2f&from=%s&to=%s',
         amount, from:upper(), to:upper()
     )
-    local data, code = http.get_json(request_url)
+    local data, _ = http.get_json(request_url)
     if not data then
         return nil, 'Currency conversion request failed. Check that the currency codes are valid.'
     end

--- a/src/plugins/utility/github.lua
+++ b/src/plugins/utility/github.lua
@@ -30,7 +30,7 @@ function plugin.on_message(api, message, ctx)
     end
 
     local api_url = string.format('https://api.github.com/repos/%s/%s', owner, repo)
-    local data, code = http.get_json(api_url, {
+    local data, _ = http.get_json(api_url, {
         ['Accept'] = 'application/vnd.github.v3+json'
     })
     if not data then

--- a/src/plugins/utility/inline.lua
+++ b/src/plugins/utility/inline.lua
@@ -52,7 +52,7 @@ local function handle_wiki(query)
         'https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch=%s&format=json&utf8=1&srlimit=5',
         encoded
     )
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data or not data.query or not data.query.search or #data.query.search == 0 then
         return { article(1, 'No results', 'No Wikipedia articles found for "' .. query .. '".',
             'No Wikipedia articles found for "' .. tools.escape_html(query) .. '".') }
@@ -78,7 +78,7 @@ end
 local function handle_ud(query)
     local encoded = url.escape(query)
     local api_url = 'https://api.urbandictionary.com/v0/define?term=' .. encoded
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data or not data.list or #data.list == 0 then
         return { article(1, 'No results', 'No definitions found for "' .. query .. '".',
             'No Urban Dictionary definitions found for "' .. tools.escape_html(query) .. '".') }
@@ -154,7 +154,7 @@ local function handle_translate(text)
         tools.escape_html(source_lang:upper()),
         tools.escape_html(translated)
     )
-    local desc = truncate(translated, 100)
+    local _ = truncate(translated, 100)
     return { article(1, translated, source_lang:upper() .. ' -> EN', message_text) }
 end
 

--- a/src/plugins/utility/lastfm.lua
+++ b/src/plugins/utility/lastfm.lua
@@ -57,7 +57,7 @@ function plugin.on_message(api, message, ctx)
         url.escape(fm_user),
         url.escape(api_key)
     )
-    local data, status = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data then
         return api.send_message(message.chat.id, 'Failed to connect to Last.fm. Please try again later.')
     end
@@ -95,7 +95,7 @@ function plugin.on_message(api, message, ctx)
         url.escape(fm_user),
         url.escape(api_key)
     )
-    local user_data, user_status = http.get_json(user_url)
+    local user_data, _ = http.get_json(user_url)
     if user_data then
         if user_data.user and user_data.user.playcount then
             table.insert(lines, string.format('\nTotal scrobbles: <code>%s</code>', user_data.user.playcount))

--- a/src/plugins/utility/pokedex.lua
+++ b/src/plugins/utility/pokedex.lua
@@ -21,7 +21,7 @@ function plugin.on_message(api, message, ctx)
 
     local query = input:lower():gsub('%s+', '-')
     local api_url = 'https://pokeapi.co/api/v2/pokemon/' .. query
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data then
         return api.send_message(message.chat.id, 'Pokemon not found. Please check the name or ID and try again.')
     end

--- a/src/plugins/utility/setloc.lua
+++ b/src/plugins/utility/setloc.lua
@@ -40,7 +40,7 @@ function plugin.on_message(api, message, ctx)
         'https://nominatim.openstreetmap.org/search?q=%s&format=json&limit=1&addressdetails=1',
         encoded
     )
-    local data, status = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data then
         return api.send_message(message.chat.id, 'Failed to geocode that address. Please try again.')
     end

--- a/src/plugins/utility/time.lua
+++ b/src/plugins/utility/time.lua
@@ -19,7 +19,7 @@ local tools = require('telegram-bot-lua.tools')
 local function geocode(query)
     local encoded = url.escape(query)
     local request_url = 'https://nominatim.openstreetmap.org/search?q=' .. encoded .. '&format=json&limit=1&addressdetails=1'
-    local data, code = http.get_json(request_url)
+    local data, _ = http.get_json(request_url)
     if not data then
         return nil, 'Geocoding request failed.'
     end
@@ -38,7 +38,7 @@ local function get_timezone(lat, lon)
         'https://timeapi.io/api/TimeZone/coordinate?latitude=%.6f&longitude=%.6f',
         lat, lon
     )
-    local data, code = http.get_json(request_url)
+    local data, _ = http.get_json(request_url)
     if not data or not data.timeZone then
         return nil, 'Timezone lookup failed.'
     end

--- a/src/plugins/utility/urbandictionary.lua
+++ b/src/plugins/utility/urbandictionary.lua
@@ -22,7 +22,7 @@ function plugin.on_message(api, message, ctx)
 
     local encoded = url.escape(input)
     local api_url = 'https://api.urbandictionary.com/v0/define?term=' .. encoded
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data then
         return api.send_message(message.chat.id, 'Failed to connect to Urban Dictionary. Please try again later.')
     end

--- a/src/plugins/utility/weather.lua
+++ b/src/plugins/utility/weather.lua
@@ -50,7 +50,7 @@ local WMO_CODES = {
 local function geocode(query)
     local encoded = url.escape(query)
     local request_url = 'https://nominatim.openstreetmap.org/search?q=' .. encoded .. '&format=json&limit=1&addressdetails=1'
-    local data, code = http.get_json(request_url)
+    local data, _ = http.get_json(request_url)
     if not data then
         return nil, 'Geocoding request failed.'
     end
@@ -72,7 +72,7 @@ local function get_weather(lat, lon)
         .. '&temperature_unit=celsius&wind_speed_unit=kmh',
         lat, lon
     )
-    local data, code = http.get_json(request_url)
+    local data, _ = http.get_json(request_url)
     if not data or not data.current then
         return nil, 'Weather API request failed.'
     end

--- a/src/plugins/utility/wikipedia.lua
+++ b/src/plugins/utility/wikipedia.lua
@@ -23,7 +23,7 @@ local function search_wikipedia(query, lang)
         'https://%s.wikipedia.org/api/rest_v1/page/summary/%s?redirect=true',
         lang, encoded
     )
-    local data, code = http.get_json(search_url, { ['Accept'] = 'application/json' })
+    local data, _ = http.get_json(search_url, { ['Accept'] = 'application/json' })
     if not data then
         return search_wikipedia_fallback(query, lang)
     end
@@ -54,7 +54,7 @@ search_wikipedia_fallback = function(query, lang)
         'https://%s.wikipedia.org/api/rest_v1/page/summary/%s?redirect=true',
         lang, title_encoded
     )
-    local summary, summary_code = http.get_json(summary_url, { ['Accept'] = 'application/json' })
+    local summary, _ = http.get_json(summary_url, { ['Accept'] = 'application/json' })
     if not summary then
         return nil, 'Failed to retrieve article summary.'
     end

--- a/src/plugins/utility/xkcd.lua
+++ b/src/plugins/utility/xkcd.lua
@@ -21,7 +21,7 @@ function plugin.on_message(api, message, ctx)
         api_url = string.format('https://xkcd.com/%s/info.0.json', input)
     elseif input and input:lower() == 'random' then
         -- Fetch latest to get the max number, then pick random
-        local latest, latest_code = http.get_json('https://xkcd.com/info.0.json')
+        local latest, _ = http.get_json('https://xkcd.com/info.0.json')
         if latest and latest.num then
             local random_num = math.random(1, latest.num)
             api_url = string.format('https://xkcd.com/%d/info.0.json', random_num)
@@ -33,7 +33,7 @@ function plugin.on_message(api, message, ctx)
         api_url = 'https://xkcd.com/info.0.json'
     end
 
-    local data, code = http.get_json(api_url)
+    local data, _ = http.get_json(api_url)
     if not data then
         return api.send_message(message.chat.id, 'Comic not found. Please check the number and try again.')
     end


### PR DESCRIPTION
## Summary

- Remove duplicate stub handler functions in router.lua (from PR #92 merge)
- Remove undefined `on_message_reaction_count` reference
- Replace unused variables (`code`, `status`, `err`) with `_` in 18 plugins
- Remove unused `PERMANENT_PLUGINS` variable from loader.lua
- Fix global assignment `_` in database.lua
- Break long line in customcaptcha.lua

Brings luacheck from 45 warnings to 0. All 595 tests pass.